### PR TITLE
Update Kotlin Gradle plugins to 2.0.21

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -1,11 +1,11 @@
 plugins {
-	kotlin("jvm") version "1.9.25"
-	kotlin("plugin.spring") version "1.9.25"
-	id("org.springframework.boot") version "3.4.0"
-	id("io.spring.dependency-management") version "1.1.6"
-	kotlin("plugin.jpa") version "1.9.25"
-	// id("io.gitlab.arturbosch.detekt") version "1.23.4" // Deaktiviert für jetzt
-	id("com.ncorti.ktfmt.gradle") version "0.18.0"
+        kotlin("jvm") version "2.0.21"
+        kotlin("plugin.spring") version "2.0.21"
+        id("org.springframework.boot") version "3.4.0"
+        id("io.spring.dependency-management") version "1.1.6"
+        kotlin("plugin.jpa") version "2.0.21"
+        // id("io.gitlab.arturbosch.detekt") version "1.23.4" // Deaktiviert für jetzt
+        id("com.ncorti.ktfmt.gradle") version "0.18.0"
 }
 
 group = "de.tubaf"


### PR DESCRIPTION
## Summary
- update all Kotlin Gradle plugins to version 2.0.21 to address Gradle 9 deprecation warnings

## Testing
- ./gradlew help --warning-mode all

------
https://chatgpt.com/codex/tasks/task_e_68df16a3dcc4832dbe397580e3d72c3a