### PR TITLE
Add room plan scraping support

### DIFF
--- a/backend/src/main/kotlin/de/tubaf/planner/controller/TestController.kt
+++ b/backend/src/main/kotlin/de/tubaf/planner/controller/TestController.kt
@@ -290,7 +290,13 @@ class TestController(
                     totalEntries = 5,
                     newEntries = 5,
                     updatedEntries = 0,
-                    studyProgramsProcessed = 1
+                    studyProgramsProcessed = 1,
+                    roomPlansProcessed = 0,
+                    roomPlanEntries = 0,
+                    roomPlanEntriesNew = 0,
+                    roomPlanEntriesUpdated = 0,
+                    roomPlanEntriesDeactivated = 0,
+                    roomsUpdatedFromPlans = 0
                 )
             )
         } catch (e: Exception) {

--- a/backend/src/main/kotlin/de/tubaf/planner/model/Room.kt
+++ b/backend/src/main/kotlin/de/tubaf/planner/model/Room.kt
@@ -3,6 +3,7 @@ package de.tubaf.planner.model
 import jakarta.persistence.*
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Size
+import java.time.LocalDate
 
 @Entity
 @Table(name = "rooms")
@@ -24,6 +25,9 @@ class Room(
     @Column(name = "room_type", length = 50)
     var roomType: RoomType? = null,
     @Column(name = "equipment", columnDefinition = "TEXT") var equipment: String? = null,
+    @Column(name = "location_description", length = 255)
+    var locationDescription: String? = null,
+    @Column(name = "plan_updated_at") var planUpdatedAt: LocalDate? = null,
     @Column(name = "active") var active: Boolean = true
 ) : BaseEntity() {
 

--- a/backend/src/main/kotlin/de/tubaf/planner/model/RoomPlanSlot.kt
+++ b/backend/src/main/kotlin/de/tubaf/planner/model/RoomPlanSlot.kt
@@ -1,0 +1,70 @@
+package de.tubaf.planner.model
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import java.time.DayOfWeek
+import java.time.LocalTime
+
+@Entity
+@Table(
+    name = "room_plan_slots",
+    uniqueConstraints =
+        [
+            UniqueConstraint(
+                name = "uk_room_plan_slot",
+                columnNames =
+                    [
+                        "room_id",
+                        "semester_id",
+                        "day_of_week",
+                        "start_time",
+                        "end_time",
+                        "course_title",
+                    ]
+            ),
+        ]
+)
+class RoomPlanSlot(
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "room_id", nullable = false)
+    var room: Room,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "semester_id", nullable = false)
+    var semester: Semester,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "day_of_week", nullable = false, length = 20)
+    var dayOfWeek: DayOfWeek,
+
+    @Column(name = "start_time", nullable = false)
+    var startTime: LocalTime,
+
+    @Column(name = "end_time", nullable = false)
+    var endTime: LocalTime,
+
+    @Column(name = "course_title", nullable = false, length = 255)
+    var courseTitle: String,
+
+    @Column(name = "course_type", length = 100)
+    var courseType: String? = null,
+
+    @Column(name = "lecturers", columnDefinition = "TEXT")
+    var lecturers: String? = null,
+
+    @Column(name = "week_pattern", length = 50)
+    var weekPattern: String? = null,
+
+    @Column(name = "info_id", length = 20)
+    var infoId: String? = null,
+
+    @Column(name = "active")
+    var active: Boolean = true,
+) : BaseEntity()

--- a/backend/src/main/kotlin/de/tubaf/planner/repository/RoomPlanSlotRepository.kt
+++ b/backend/src/main/kotlin/de/tubaf/planner/repository/RoomPlanSlotRepository.kt
@@ -1,0 +1,11 @@
+package de.tubaf.planner.repository
+
+import de.tubaf.planner.model.RoomPlanSlot
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface RoomPlanSlotRepository : JpaRepository<RoomPlanSlot, Long> {
+
+    fun findByRoomIdAndSemesterId(roomId: Long, semesterId: Long): List<RoomPlanSlot>
+}

--- a/backend/src/main/resources/db/migration/V2__Room_Plan_Support.sql
+++ b/backend/src/main/resources/db/migration/V2__Room_Plan_Support.sql
@@ -1,0 +1,33 @@
+-- Add metadata fields for room plans
+ALTER TABLE rooms
+    ADD COLUMN IF NOT EXISTS location_description VARCHAR(255);
+
+ALTER TABLE rooms
+    ADD COLUMN IF NOT EXISTS plan_updated_at DATE;
+
+-- Table for scraped room plan slots
+CREATE TABLE IF NOT EXISTS room_plan_slots (
+    id BIGSERIAL PRIMARY KEY,
+    room_id BIGINT NOT NULL REFERENCES rooms(id) ON DELETE CASCADE,
+    semester_id BIGINT NOT NULL REFERENCES semesters(id) ON DELETE CASCADE,
+    day_of_week VARCHAR(20) NOT NULL,
+    start_time TIME NOT NULL,
+    end_time TIME NOT NULL,
+    course_title VARCHAR(255) NOT NULL,
+    course_type VARCHAR(100),
+    lecturers TEXT,
+    week_pattern VARCHAR(50),
+    info_id VARCHAR(20),
+    active BOOLEAN DEFAULT TRUE,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uk_room_plan_slot
+    ON room_plan_slots (room_id, semester_id, day_of_week, start_time, end_time, course_title);
+
+CREATE INDEX IF NOT EXISTS idx_room_plan_slots_room
+    ON room_plan_slots (room_id);
+
+CREATE INDEX IF NOT EXISTS idx_room_plan_slots_semester
+    ON room_plan_slots (semester_id);


### PR DESCRIPTION
## Summary
- extend the scraper to fetch room plan options, parse room plan HTML exports, and persist the resulting slots while updating room metadata
- add a dedicated RoomPlanSlot entity, repository, and Flyway migration so room plan information is stored per room and semester
- widen the scraping result DTO and related controller to expose room plan counters alongside existing schedule statistics

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68df242b7890832d8f23430db95ff2ef