### PR TITLE
Add scraping verification workflow with JSON report output

### DIFF
--- a/.github/workflows/scraper-check.yml
+++ b/.github/workflows/scraper-check.yml
@@ -1,0 +1,67 @@
+name: Scraper Verification
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - 'backend/**'
+      - '.github/workflows/scraper-check.yml'
+  pull_request:
+    paths:
+      - 'backend/**'
+      - '.github/workflows/scraper-check.yml'
+
+jobs:
+  scraper-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: gradle
+
+      - name: Run scraper verification
+        id: scraper-test
+        continue-on-error: true
+        working-directory: backend
+        run: |
+          set -eo pipefail
+          ./gradlew test --tests "de.tubaf.planner.ScrapingJsonReportTest" | tee ../scraper-report.log
+
+      - name: Publish scraping report
+        if: always()
+        run: |
+          if [ ! -f scraper-report.log ]; then
+            echo "scraper-report.log not found" >&2
+            exit 1
+          fi
+
+          start_line=$(grep -n "SCRAPING_REPORT_START" scraper-report.log | cut -d: -f1 | tail -n 1)
+          end_line=$(grep -n "SCRAPING_REPORT_END" scraper-report.log | cut -d: -f1 | tail -n 1)
+
+          if [ -z "$start_line" ] || [ -z "$end_line" ]; then
+            echo "Scraping report markers not found" >&2
+            exit 1
+          fi
+
+          start_line=$((start_line + 1))
+          end_line=$((end_line - 1))
+
+          report=$(sed -n "${start_line},${end_line}p" scraper-report.log)
+          echo "Scraping report:" "$report"
+          {
+            echo "## Scraping Report"
+            echo '```json'
+            echo "$report"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Fail if scraper verification failed
+        if: steps.scraper-test.outcome == 'failure'
+        run: exit 1

--- a/backend/src/test/kotlin/de/tubaf/planner/ScrapingJsonReportTest.kt
+++ b/backend/src/test/kotlin/de/tubaf/planner/ScrapingJsonReportTest.kt
@@ -1,0 +1,91 @@
+package de.tubaf.planner
+
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import de.tubaf.planner.service.SemesterService
+import de.tubaf.planner.service.scraping.TubafScrapingService
+import java.time.Instant
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.fail
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+
+@SpringBootTest
+@ActiveProfiles("test")
+class ScrapingJsonReportTest {
+
+    @Autowired private lateinit var tubafScrapingService: TubafScrapingService
+
+    @Autowired private lateinit var semesterService: SemesterService
+
+    @Value("\${tubaf.scraper.base-url:https://evlvz.hrz.tu-freiberg.de/~vover/}")
+    private lateinit var baseUrl: String
+
+    private val objectMapper =
+        jacksonObjectMapper().registerModule(JavaTimeModule()).disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+
+    @Test
+    fun generateScrapingReport() {
+        val semesters = semesterService.getAllSemesters()
+        val semesterReports = mutableListOf<Map<String, Any?>>()
+        val failures = mutableListOf<String>()
+
+        semesters.forEach { semester ->
+            val start = Instant.now()
+            val semesterReport = mutableMapOf<String, Any?>(
+                "id" to semester.id,
+                "name" to semester.name,
+                "shortName" to semester.shortName,
+                "startedAt" to start,
+            )
+
+            try {
+                val result = tubafScrapingService.scrapeSemesterData(semester)
+                val finishedAt = Instant.now()
+                semesterReport +=
+                    mapOf(
+                        "status" to "SUCCESS",
+                        "finishedAt" to finishedAt,
+                        "durationMillis" to (finishedAt.toEpochMilli() - start.toEpochMilli()),
+                        "result" to result,
+                    )
+            } catch (ex: Exception) {
+                val finishedAt = Instant.now()
+                semesterReport +=
+                    mapOf(
+                        "status" to "FAILED",
+                        "finishedAt" to finishedAt,
+                        "durationMillis" to (finishedAt.toEpochMilli() - start.toEpochMilli()),
+                        "error" to
+                            mapOf(
+                                "type" to ex::class.qualifiedName,
+                                "message" to (ex.message ?: "Unknown error"),
+                            ),
+                    )
+                failures += "${semester.shortName}: ${ex.message ?: ex::class.qualifiedName}".trim()
+            }
+
+            semesterReports += semesterReport
+        }
+
+        val report =
+            mapOf(
+                "generatedAt" to Instant.now(),
+                "baseUrl" to baseUrl,
+                "semesterCount" to semesters.size,
+                "semesters" to semesterReports,
+            )
+
+        val json = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(report)
+        println("SCRAPING_REPORT_START")
+        println(json)
+        println("SCRAPING_REPORT_END")
+
+        if (failures.isNotEmpty()) {
+            fail("Scraping failed for semesters: ${failures.joinToString(", ")}")
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that runs the scraping verification test and publishes the JSON output to the job summary
- implement a Spring Boot test that executes the scraper for all semesters and prints a structured JSON report surrounded by markers for the workflow to capture

## Testing
- not run (network-dependent scraping test)

------
https://chatgpt.com/codex/tasks/task_e_68df2cb119f0832dac242f6808054a7c