### PR TITLE
Expose scraper report output in CI logs

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -100,7 +100,11 @@ allOpen {
 }
 
 tasks.withType<Test> {
-	useJUnitPlatform()
+        useJUnitPlatform()
+
+        testLogging {
+                showStandardStreams = true
+        }
 }
 
 // Code Quality & Formatting


### PR DESCRIPTION
## Summary
- enable Gradle test logging to display standard streams so the scraper report markers are captured in CI

## Testing
- not run (tests require live scraping and were aborted locally)


------
https://chatgpt.com/codex/tasks/task_e_68df7416cce0832db31ed5b73cfca25a