### PR TITLE
Enable proper scraping cancellation handling

### DIFF
--- a/backend/src/main/resources/templates/data/scraping.html
+++ b/backend/src/main/resources/templates/data/scraping.html
@@ -592,14 +592,30 @@
         async function cancelScraping() {
             try {
                 const response = await fetch('/api/scraping/cancel', { method: 'POST' });
-                const data = await response.json();
-                addLog('warning', 'Scraping wurde abgebrochen');
-                showNotification('Scraping wurde abgebrochen', 'warning');
+                let data = {};
+
+                try {
+                    data = await response.json();
+                } catch (_) {
+                    // ignore JSON parse errors and fall back to defaults
+                }
+
+                if (!response.ok || data.success === false) {
+                    const message = data.message || 'Abbrechen fehlgeschlagen';
+                    throw new Error(message);
+                }
+
+                const message = data.message || 'Scraping wurde abgebrochen';
+                addLog('warning', message);
+                showNotification(message, 'warning');
                 stopElapsedTimer();
                 stopAutoRefresh();
+                updateUI('idle');
+                await refreshStatus();
             } catch (error) {
                 console.error('Error:', error);
-                addLog('error', 'Fehler beim Abbrechen');
+                addLog('error', 'Fehler beim Abbrechen: ' + error.message);
+                showNotification('Fehler beim Abbrechen: ' + error.message, 'error');
             }
         }
         
@@ -609,7 +625,9 @@
                 const response = await fetch('/api/scraping/status');
                 const data = await response.json();
                 
-                updateStatusIndicator(data.status || 'idle');
+                const status = (data.status || 'idle').toLowerCase();
+                updateStatusIndicator(status);
+                updateUI(status === 'running' ? 'running' : 'idle');
                 updateProgress(data);
                 
                 if (data.logs && data.logs.length > 0) {
@@ -618,7 +636,7 @@
                     });
                 }
                 
-                if (data.status !== 'running') {
+                if (status !== 'running') {
                     stopElapsedTimer();
                     stopAutoRefresh();
                 }


### PR DESCRIPTION
## Summary
- implement the cancel endpoint to stop a running scraping job and surface meaningful responses
- improve the scraping UI's cancel flow and status polling to react to backend cancellation results

## Testing
- `./gradlew test --console=plain` *(fails: Testcontainers requires a Docker environment in CI)*

------
https://chatgpt.com/codex/tasks/task_e_68e2b1d0eb6c832d851235fea808ec41