### PR TITLE
Fix progress updates for parallel semester scraping

### DIFF
--- a/backend/src/main/kotlin/de/tubaf/planner/service/scraping/TubafScrapingService.kt
+++ b/backend/src/main/kotlin/de/tubaf/planner/service/scraping/TubafScrapingService.kt
@@ -116,7 +116,13 @@ open class TubafScrapingService(
         wrapper.inUse.set(0)
     }
 
-    private fun parallelScrapePrograms(semester: Semester, scrapingRunId: Long, programs: List<StudyProgramOption>, stats: ScrapeStats) {
+    private fun parallelScrapePrograms(
+        semester: Semester,
+        scrapingRunId: Long,
+        programs: List<StudyProgramOption>,
+        stats: ScrapeStats,
+        subTaskId: String?,
+    ) {
         if (programs.isEmpty()) return
 
         val maxWorkers = scrapingConfiguration.parallelMaxWorkers.coerceAtLeast(1)
@@ -177,6 +183,14 @@ open class TubafScrapingService(
                             total = programs.size,
                             message = updateMsg,
                         )
+                        if (subTaskId != null) {
+                            progressTracker.updateSubTask(
+                                id = subTaskId,
+                                processed = done,
+                                total = programs.size,
+                                message = updateMsg,
+                            )
+                        }
                         if (interDelay > 0) {
                             Thread.sleep(interDelay)
                         }
@@ -459,7 +473,7 @@ open class TubafScrapingService(
                     )
                 }
 
-                if (!trackProgress && subTaskId != null) {
+                if (subTaskId != null) {
                     progressTracker.updateSubTask(
                         id = subTaskId,
                         processed = 0,
@@ -469,7 +483,7 @@ open class TubafScrapingService(
                 }
 
                 if (scrapingConfiguration.parallelEnabled) {
-                    parallelScrapePrograms(semester, scrapingRun.id!!, programs, stats)
+                    parallelScrapePrograms(semester, scrapingRun.id!!, programs, stats, subTaskId)
                 } else {
                     programs.forEachIndexed { index, program ->
                         ensureNotCancelled()


### PR DESCRIPTION
## Summary
- update the parallel scraping worker to propagate sub-task progress updates for each finished study program
- initialize the semester sub-task totals as soon as study programs are discovered so intermediate progress can be shown

## Testing
- ./gradlew test --console=plain *(fails: CourseUniqueIndexIntegrationTest requires Docker/Testcontainers)*

------
https://chatgpt.com/codex/tasks/task_e_68e2bf80f344832da0ad92eca9bd6903