### PR TITLE
Detach unsaved course types after concurrent creation failures

### DIFF
--- a/backend/src/main/kotlin/de/tubaf/planner/service/scraping/TubafScrapingService.kt
+++ b/backend/src/main/kotlin/de/tubaf/planner/service/scraping/TubafScrapingService.kt
@@ -18,6 +18,7 @@ import de.tubaf.planner.service.SemesterService
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.Timer
 import jakarta.annotation.PreDestroy
+import jakarta.persistence.EntityManager
 import okhttp3.FormBody
 import okhttp3.JavaNetCookieJar
 import okhttp3.OkHttpClient
@@ -64,6 +65,7 @@ open class TubafScrapingService(
     private val scrapingConfiguration: ScrapingConfiguration,
     private val transactionManager: PlatformTransactionManager,
     private val meterRegistry: MeterRegistry,
+    private val entityManager: EntityManager,
     @Value("\${tubaf.scraper.base-url:https://evlvz.hrz.tu-freiberg.de/~vover}")
     private val baseUrl: String,
     @Value("\${tubaf.scraper.encoding.fix-legacy:true}")
@@ -918,6 +920,7 @@ open class TubafScrapingService(
             saved
         } catch (ex: DataIntegrityViolationException) {
             logger.debug("Parallel creation race for course type {}", code, ex)
+            entityManager.detach(newType)
             courseTypeRepository.findByCode(code)
                 ?: throw ex
         }


### PR DESCRIPTION
## Summary
- inject the JPA EntityManager into the scraping service so newly created course types can be managed explicitly
- detach failed CourseType instances after DataIntegrity violations to avoid null identifier errors during parallel scraping

## Testing
- ./gradlew test *(fails: Testcontainers cannot locate a Docker environment in this CI sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68e2e42f0d48832da8f8e8cd058b85ce