### PR TITLE
Fix overall progress bar during parallel scraping

### DIFF
--- a/backend/src/main/kotlin/de/tubaf/planner/service/scraping/TubafScrapingService.kt
+++ b/backend/src/main/kotlin/de/tubaf/planner/service/scraping/TubafScrapingService.kt
@@ -125,6 +125,7 @@ open class TubafScrapingService(
         programs: List<StudyProgramOption>,
         stats: ScrapeStats,
         subTaskId: String?,
+        trackProgress: Boolean,
     ) {
         if (programs.isEmpty()) return
 
@@ -180,12 +181,14 @@ open class TubafScrapingService(
                         releaseSession(sessionWrapper)
                         val done = completed.incrementAndGet()
                         val updateMsg = program.code + " abgeschlossen (" + done + "/" + programs.size + ")"
-                        progressTracker.update(
-                            task = "Parallel " + semester.shortName,
-                            processed = done,
-                            total = programs.size,
-                            message = updateMsg,
-                        )
+                        if (trackProgress) {
+                            progressTracker.update(
+                                task = "Parallel " + semester.shortName,
+                                processed = done,
+                                total = programs.size,
+                                message = updateMsg,
+                            )
+                        }
                         if (subTaskId != null) {
                             progressTracker.updateSubTask(
                                 id = subTaskId,
@@ -486,7 +489,14 @@ open class TubafScrapingService(
                 }
 
                 if (scrapingConfiguration.parallelEnabled) {
-                    parallelScrapePrograms(semester, scrapingRun.id!!, programs, stats, subTaskId)
+                    parallelScrapePrograms(
+                        semester,
+                        scrapingRun.id!!,
+                        programs,
+                        stats,
+                        subTaskId,
+                        trackProgress,
+                    )
                 } else {
                     programs.forEachIndexed { index, program ->
                         ensureNotCancelled()


### PR DESCRIPTION
## Summary
- avoid overriding aggregated scraping progress when parallel workers run without single-semester tracking
- plumb the trackProgress flag into parallel scraping so the UI keeps showing global progress across semesters

## Testing
- ./gradlew test --console=plain *(fails: requires a Docker environment for Testcontainers and cannot write XML results)*

------
https://chatgpt.com/codex/tasks/task_e_68e36fc221e8832da036dd98d064c430