### PR TITLE
Improve parallel scraping robustness and log filtering

### DIFF
--- a/backend/src/main/resources/templates/data/scraping.html
+++ b/backend/src/main/resources/templates/data/scraping.html
@@ -57,6 +57,12 @@
             background-color: #f8d7da;
             border-color: #dc3545;
         }
+
+        .log-entry.debug {
+            background-color: #f1f3f5;
+            border-color: #6c757d;
+            color: #495057;
+        }
         
         .stat-card {
             transition: transform 0.2s, box-shadow 0.2s;
@@ -446,13 +452,22 @@
                     
                     <!-- Logs Card -->
                     <div class="card border-0 shadow-sm">
-                        <div class="card-header bg-white border-0 py-3 d-flex justify-content-between align-items-center">
+                        <div class="card-header bg-white border-0 py-3 d-flex flex-wrap justify-content-between align-items-center gap-2">
                             <h5 class="mb-0">
                                 <i class="fas fa-terminal me-2 text-primary"></i>Live-Logs
                             </h5>
-                            <button class="btn btn-sm btn-outline-secondary" onclick="clearLogs()">
-                                <i class="fas fa-trash-alt me-1"></i>Löschen
-                            </button>
+                            <div class="d-flex align-items-center gap-2 flex-wrap">
+                                <div class="btn-group btn-group-sm" role="group" aria-label="Log-Level-Filter">
+                                    <button type="button" class="btn btn-outline-secondary" data-log-filter="all" onclick="setLogFilter('all', this)">Alle</button>
+                                    <button type="button" class="btn btn-outline-secondary" data-log-filter="info" onclick="setLogFilter('info', this)">Info</button>
+                                    <button type="button" class="btn btn-outline-secondary" data-log-filter="warn" onclick="setLogFilter('warn', this)">Warnung</button>
+                                    <button type="button" class="btn btn-outline-secondary" data-log-filter="error" onclick="setLogFilter('error', this)">Fehler</button>
+                                    <button type="button" class="btn btn-outline-secondary" data-log-filter="debug" onclick="setLogFilter('debug', this)">Debug</button>
+                                </div>
+                                <button class="btn btn-sm btn-outline-secondary" onclick="clearLogs()">
+                                    <i class="fas fa-trash-alt me-1"></i>Löschen
+                                </button>
+                            </div>
                         </div>
                         <div class="card-body p-0">
                             <div id="logContainer" class="p-3" style="max-height: 400px; overflow-y: auto; background: #f8f9fa;">
@@ -572,6 +587,19 @@
         let startTime = null;
         let elapsedTimer = null;
         let latestLogTimestamp = null;
+        const logEntries = [];
+        let currentLogFilter = 'all';
+        let currentLogFilterButton = null;
+        const MAX_LOG_ENTRIES = 400;
+        const LOG_LEVEL_CLASS = {
+            info: 'info',
+            success: 'success',
+            warn: 'warning',
+            warning: 'warning',
+            error: 'error',
+            danger: 'error',
+            debug: 'debug'
+        };
         let availableSemesters = [];
         const selectedSemesters = new Set();
         
@@ -711,7 +739,7 @@
                     });
 
                     newLogs.forEach(log => {
-                        addLog(log.level.toLowerCase(), log.message, false, log.timestamp);
+                        addLog(log.level, log.message, false, log.timestamp, log.detail);
 
                         let logTime = log.timestamp ? new Date(log.timestamp).getTime() : Date.now();
                         if (Number.isNaN(logTime)) {
@@ -824,50 +852,131 @@
             }
         }
         
-        // Add Log Entry
-        function addLog(level, message, scroll = true, timestamp = null) {
+        function normalizeLogLevel(level) {
+            if (!level) return 'info';
+            const normalized = level.toString().toLowerCase();
+            if (normalized === 'warn' || normalized === 'warning') return 'warn';
+            if (normalized === 'error' || normalized === 'danger') return 'error';
+            if (normalized === 'debug') return 'debug';
+            if (normalized === 'success') return 'success';
+            return 'info';
+        }
+
+        function levelMatchesFilter(level) {
+            switch (currentLogFilter) {
+                case 'info':
+                    return level === 'info' || level === 'success';
+                case 'warn':
+                    return level === 'warn';
+                case 'error':
+                    return level === 'error';
+                case 'debug':
+                    return level === 'debug';
+                default:
+                    return true;
+            }
+        }
+
+        function renderLogList(scrollToBottom = false) {
             const container = document.getElementById('logContainer');
+            if (!container) return;
 
-            // Remove empty state
-            if (container.querySelector('.text-center')) {
-                container.innerHTML = '';
+            container.innerHTML = '';
+
+            const visibleEntries = logEntries.filter(entry => levelMatchesFilter(entry.level));
+
+            if (visibleEntries.length === 0) {
+                container.innerHTML = `
+                    <div class="text-center text-muted py-5">
+                        <i class="fas fa-info-circle fa-2x mb-2"></i>
+                        <p class="mb-0">Keine Logs verfügbar</p>
+                        <small>Starte ein Scraping, um Logs zu sehen</small>
+                    </div>
+                `;
+                return;
             }
 
-            const entry = document.createElement('div');
-            entry.className = `log-entry ${level}`;
+            visibleEntries.forEach(entry => {
+                const cssClass = LOG_LEVEL_CLASS[entry.level] || 'info';
+                const row = document.createElement('div');
+                row.className = `log-entry ${cssClass}`;
 
-            const parsedTimestamp = timestamp ? new Date(timestamp) : null;
-            const time = parsedTimestamp && !Number.isNaN(parsedTimestamp.getTime())
-                ? parsedTimestamp.toLocaleTimeString('de-DE')
-                : new Date().toLocaleTimeString('de-DE');
-            entry.innerHTML = `
-                <div class="d-flex justify-content-between align-items-start">
-                    <span class="flex-grow-1">${escapeHtml(message)}</span>
-                    <small class="text-muted ms-2">${time}</small>
-                </div>
-            `;
-            
-            container.appendChild(entry);
-            
-            // Keep only last 100 entries
-            while (container.children.length > 100) {
-                container.removeChild(container.firstChild);
-            }
-            
-            if (scroll) {
+                const time = entry.timestamp
+                    ? entry.timestamp.toLocaleTimeString('de-DE')
+                    : new Date().toLocaleTimeString('de-DE');
+
+                row.innerHTML = `
+                    <div class="d-flex justify-content-between align-items-start">
+                        <span class="flex-grow-1">${escapeHtml(entry.message)}</span>
+                        <small class="text-muted ms-2">${time}</small>
+                    </div>
+                `;
+
+                if (entry.detail) {
+                    const detailsEl = document.createElement('details');
+                    detailsEl.className = 'mt-2';
+                    const summary = document.createElement('summary');
+                    summary.className = 'small text-muted';
+                    summary.textContent = 'Details';
+                    const pre = document.createElement('pre');
+                    pre.className = 'small text-muted mb-0';
+                    pre.textContent = entry.detail;
+                    detailsEl.appendChild(summary);
+                    detailsEl.appendChild(pre);
+                    row.appendChild(detailsEl);
+                }
+
+                container.appendChild(row);
+            });
+
+            if (scrollToBottom) {
                 container.scrollTop = container.scrollHeight;
             }
         }
-        
+
+        // Add Log Entry
+        function addLog(level, message, scroll = true, timestamp = null, detail = null) {
+            const normalizedLevel = normalizeLogLevel(level);
+            const text = typeof message === 'string' ? message : String(message ?? '');
+            const detailText = detail != null ? String(detail) : null;
+
+            let parsedTimestamp = timestamp ? new Date(timestamp) : new Date();
+            if (Number.isNaN(parsedTimestamp.getTime())) {
+                parsedTimestamp = new Date();
+            }
+
+            logEntries.push({
+                level: normalizedLevel,
+                message: text,
+                detail: detailText,
+                timestamp: parsedTimestamp
+            });
+
+            while (logEntries.length > MAX_LOG_ENTRIES) {
+                logEntries.shift();
+            }
+
+            const shouldScroll = scroll && (currentLogFilter === 'all' || levelMatchesFilter(normalizedLevel));
+            renderLogList(shouldScroll);
+        }
+
+        function setLogFilter(level, button) {
+            currentLogFilter = level;
+            if (currentLogFilterButton) {
+                currentLogFilterButton.classList.remove('active');
+            }
+            if (button) {
+                button.classList.add('active');
+                currentLogFilterButton = button;
+            }
+            renderLogList(false);
+        }
+
         // Clear Logs
         function clearLogs() {
             latestLogTimestamp = null;
-            document.getElementById('logContainer').innerHTML = `
-                <div class="text-center text-muted py-5">
-                    <i class="fas fa-info-circle fa-2x mb-2"></i>
-                    <p class="mb-0">Keine Logs verfügbar</p>
-                </div>
-            `;
+            logEntries.length = 0;
+            renderLogList(false);
         }
         
         // Elapsed Timer
@@ -1081,7 +1190,14 @@
             refreshStatus();
             loadAvailableSemesters();
             loadConfig();
-            
+
+            const defaultFilterBtn = document.querySelector('[data-log-filter="all"]');
+            if (defaultFilterBtn) {
+                setLogFilter('all', defaultFilterBtn);
+            } else {
+                renderLogList(false);
+            }
+
             document.getElementById('autoRefresh').addEventListener('change', function() {
                 if (this.checked) {
                     startAutoRefresh();


### PR DESCRIPTION
## Summary
- Rework the parallel scraping session pool to recover from failures, refresh sessions automatically, and surface aggregated errors with detailed progress logging
- Extend the scraping progress tracker with typed log levels, structured log entries, and optional stack traces for improved diagnostics
- Update the scraping dashboard to provide log level filters, retain recent entries client-side, and display expandable error details

## Testing
- `./gradlew --console=plain test` *(fails: Docker not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e385280a30832dbd8a738a99351a17