### PR TITLE
Fix Chart.js WebJar path in base layout

### DIFF
--- a/backend/src/main/resources/templates/layout/base.html
+++ b/backend/src/main/resources/templates/layout/base.html
@@ -74,6 +74,6 @@
     <!-- Scripts -->
     <script th:src="@{/webjars/bootstrap/js/bootstrap.bundle.min.js}"></script>
     <script th:src="@{/webjars/jquery/jquery.min.js}"></script>
-    <script th:src="@{/webjars/chart.js/chart.min.js}"></script>
+    <script th:src="@{/webjars/chart.js/dist/chart.umd.min.js}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- update the base layout to load Chart.js from the correct WebJar location so the script can be resolved without a CDN fallback

## Testing
- ./gradlew test *(fails: Testcontainers requires a Docker daemon in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e39e26fb00832db2556e9afbcac1df