### PR TITLE
Enable default parallel scraping and improve concurrency safety

### DIFF
--- a/backend/src/main/kotlin/de/tubaf/planner/config/ScrapingConfiguration.kt
+++ b/backend/src/main/kotlin/de/tubaf/planner/config/ScrapingConfiguration.kt
@@ -17,7 +17,7 @@ class ScrapingConfiguration {
 
     // Parallelisierungs-Optionen
     // Aktiviert die parallele Verarbeitung der Studiengänge innerhalb eines Semesters
-    var parallelEnabled: Boolean = false
+    var parallelEnabled: Boolean = true
 
     // Maximale Anzahl gleichzeitiger Worker (Programme), begrenzt durch Session-Pool Größe
     var parallelMaxWorkers: Int = 4
@@ -26,7 +26,7 @@ class ScrapingConfiguration {
     var parallelSessionPoolSize: Int = 2
 
     // Optionale kurze Pause (ms) zwischen abgeschlossenen Tasks um Server nicht zu fluten
-    var parallelInterTaskDelay: Long = 150
+    var parallelInterTaskDelay: Long = 100
 
     /*
      * Hinweise zur Parallelisierung (Variante B – Session Pool):

--- a/backend/src/main/kotlin/de/tubaf/planner/service/scraping/TubafScrapingService.kt
+++ b/backend/src/main/kotlin/de/tubaf/planner/service/scraping/TubafScrapingService.kt
@@ -47,12 +47,12 @@ import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalTime
 import java.time.format.DateTimeFormatter
-import java.util.Collections
 import java.util.EnumMap
 import java.util.Locale
 import java.util.concurrent.ArrayBlockingQueue
 import java.util.concurrent.BlockingQueue
 import java.util.concurrent.Callable
+import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
@@ -226,7 +226,7 @@ open class TubafScrapingService(
         }
 
         val completed = AtomicInteger(0)
-        val errors = Collections.synchronizedList(mutableListOf<Pair<StudyProgramOption, Throwable>>())
+        val errors = CopyOnWriteArrayList<Pair<StudyProgramOption, Throwable>>()
 
         val futures = programs.map { program ->
             workerExecutor.submit(


### PR DESCRIPTION
## Summary
- enable the session-pool based parallel scraping mode by default and reduce the inter task delay to 100ms
- replace the synchronized list used for collecting parallel scraping errors with a CopyOnWriteArrayList to avoid race conditions when aggregating failures

## Testing
- `./gradlew test --console=plain` *(fails: Testcontainers cannot start because Docker is unavailable in the CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4015ccdd8832da6278d5ca299dcf4